### PR TITLE
Fix Awair's GraphQL errors

### DIFF
--- a/python_awair/const.py
+++ b/python_awair/const.py
@@ -44,8 +44,8 @@ Devices {
                 location {
                     name
                     timezone
-                    lat
-                    lon
+                    latitude
+                    longitude
                 }
             }
         }


### PR DESCRIPTION
Awair changed their notation for `lat` to `latitude` and `lon` to `longitude`