### PR TITLE
local sensors API support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,6 @@ venv.bak/
 .mypy_cache/
 
 script/
+
+# PyCharm/IntelliJ project directory
+/.idea

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -140,3 +140,61 @@ Fetching data from a different time
           print(f"{sensor}: {round(value, 2)}")
           if sensor in datum.indices:
             print(f"  awair index: {datum.indices[sensor]}")
+
+Sample local sensors program
+=================================
+
+Awair recently added the `local sensors API`_, where you can retrieve current (and only current)
+air data from devices on your local network over HTTP.
+
+.. _`local sensors API`: https://docs.google.com/document/d/1001C-ro_ig7aEyz0GiWUiiJn0M6DLj47BYWj31acesg/edit
+
+.. code:: python
+
+  import asyncio
+  import aiohttp
+  from python_awair import AwairLocal
+
+  async def data():
+      async with aiohttp.ClientSession() as session:
+          # Instantiate a client with your access token, and an asyncio session:
+          client = AwairLocal(
+              session=session, device_addrs=["AWAIR-ELEM-1419E1.local"]
+          )
+
+          # List the local devices:
+          devices = await client.devices()
+
+          # Get some air quality data for a user's device:
+          data = await devices[0].air_data_latest()
+
+          # Print things out!
+          print(f"Device: {devices[0]}")
+
+          # You can access sensors as dict items:
+          for sensor, value in data.sensors.items():
+              print(f"  {sensor}: {round(value, 2)}")
+
+          # Or, as attributes:
+          print(f"  temperature again: {round(data.sensors.temperature, 2)}")
+
+  asyncio.run(data())
+
+Running this sample prints::
+
+  $ python awair_local_demo.py
+  Device: <AwairDevice: uuid=awair-element_5366 model=Awair Element>
+    dew_point: 10.81
+    abs_humid: 9.59
+    co2_est: 461
+    voc_baseline: 2536742680
+    voc_h2_raw: 27
+    voc_ethanol_raw: 39
+    pm10_est: 3
+    temperature: 19.16
+    humidity: 58.46
+    carbon_dioxide: 438
+    volatile_organic_compounds: 384
+    particulate_matter_2_5: 2
+    temperature again: 19.16
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "python-awair"
-version = "0.1.1"
+version = "0.2.0"
 description = "asyncio client for the Awair GraphQL API"
 authors = ["Andrew Hayworth <ahayworth@gmail.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ whitelist_externals = poetry
 commands =
   poetry run black . --check
   poetry run isort --check python_awair/ tests/
-  poetry run flake8
+  poetry run flake8 python_awair/ tests/
   poetry run pylint python_awair/ tests/
   poetry run mypy python_awair/ tests/
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ commands = poetry run pytest {posargs}
 whitelist_externals = poetry
 commands =
   poetry run black . --check
-  poetry run isort -c
+  poetry run isort --check python_awair/ tests/
   poetry run flake8
   poetry run pylint python_awair/ tests/
   poetry run mypy python_awair/ tests/

--- a/tests/const.py
+++ b/tests/const.py
@@ -30,3 +30,13 @@ MOCK_GLOW_DEVICE_ATTRS = {
     "deviceUUID": "awair-glow_1405",
 }
 MOCK_USER_ATTRS = {"id": "32406"}
+MOCK_ELEMENT_DEVICE_A_ATTRS = {
+    "deviceId": 6049,
+    "deviceType": "awair-element",
+    "deviceUUID": "awair-element_6049",
+}
+MOCK_ELEMENT_DEVICE_B_ATTRS = {
+    "deviceId": 5366,
+    "deviceType": "awair-element",
+    "deviceUUID": "awair-element_5366",
+}

--- a/tests/fixtures/cassettes/latest_local.yaml
+++ b/tests/fixtures/cassettes/latest_local.yaml
@@ -1,0 +1,48 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Content-Type:
+      - application/json
+      authorization:
+      - fake_token
+    method: GET
+    uri: http://awair-elem-1419e1.local/settings/config/data
+  response:
+    body:
+      string: '{"device_uuid":"awair-element_5366","wifi_mac":"70:88:6B:14:19:E1","ssid":"morpac-east","ip":"192.168.1.225","netmask":"255.255.255.0","gateway":"none","fw_version":"1.1.5","timezone":"America/Los_Angeles","display":"co2","led":{"mode":"manual","brightness":73},"voc_feature_set":"Unknown"}'
+    headers:
+      Access-Control-Allow-Origin: '*'
+      Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Connection: Keep-Alive
+      Content-Type: application/json
+      Pragma: no-cache
+      Transfer-Encoding: chunked
+    status:
+      code: 200
+      message: OK
+    url: http://awair-elem-1419e1.local/settings/config/data
+- request:
+    body: null
+    headers:
+      Content-Type:
+      - application/json
+      authorization:
+      - fake_token
+    method: GET
+    uri: http://awair-elem-1419e1.local/air-data/latest
+  response:
+    body:
+      string: '{"timestamp":"2020-08-31T22:07:03.831Z","score":93,"dew_point":11.11,"temp":19.59,"humid":58.05,"abs_humid":9.77,"co2":408,"co2_est":400,"voc":159,"voc_baseline":2533859097,"voc_h2_raw":28,"voc_ethanol_raw":40,"pm25":2,"pm10_est":3}'
+    headers:
+      Access-Control-Allow-Origin: '*'
+      Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Connection: Keep-Alive
+      Content-Type: application/json
+      Pragma: no-cache
+      Transfer-Encoding: chunked
+    status:
+      code: 200
+      message: OK
+    url: http://awair-elem-1419e1.local/air-data/latest
+version: 1

--- a/tests/fixtures/cassettes/local_devices.yaml
+++ b/tests/fixtures/cassettes/local_devices.yaml
@@ -1,0 +1,48 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Content-Type:
+      - application/json
+      authorization:
+      - fake_token
+    method: GET
+    uri: http://awair-elem-1416dc.local/settings/config/data
+  response:
+    body:
+      string: '{"device_uuid":"awair-element_6049","wifi_mac":"70:88:6B:14:16:DC","ssid":"morpac-east","ip":"192.168.1.133","netmask":"255.255.255.0","gateway":"none","fw_version":"1.1.5","timezone":"America/Los_Angeles","display":"clock","led":{"mode":"auto","brightness":179},"voc_feature_set":"Unknown"}'
+    headers:
+      Access-Control-Allow-Origin: '*'
+      Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Connection: Keep-Alive
+      Content-Type: application/json
+      Pragma: no-cache
+      Transfer-Encoding: chunked
+    status:
+      code: 200
+      message: OK
+    url: http://awair-elem-1416dc.local/settings/config/data
+- request:
+    body: null
+    headers:
+      Content-Type:
+      - application/json
+      authorization:
+      - fake_token
+    method: GET
+    uri: http://awair-elem-1419e1.local/settings/config/data
+  response:
+    body:
+      string: '{"device_uuid":"awair-element_5366","wifi_mac":"70:88:6B:14:19:E1","ssid":"morpac-east","ip":"192.168.1.225","netmask":"255.255.255.0","gateway":"none","fw_version":"1.1.5","timezone":"America/Los_Angeles","display":"co2","led":{"mode":"manual","brightness":73},"voc_feature_set":"Unknown"}'
+    headers:
+      Access-Control-Allow-Origin: '*'
+      Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Connection: Keep-Alive
+      Content-Type: application/json
+      Pragma: no-cache
+      Transfer-Encoding: chunked
+    status:
+      code: 200
+      message: OK
+    url: http://awair-elem-1419e1.local/settings/config/data
+version: 1


### PR DESCRIPTION
This adds support for the local sensors API that individual devices
expose.  I tried a few different approaches, but it seems like a
distinct top level entrypoint and subclassing of `AwairDevice` was the
cleanest approach here.  It has been... a while since I've done much
Python, happy to iterate on this.

Fixes #8