### PR TITLE
Use poetry-core as build backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,5 +77,5 @@ commands =
 """
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Use [`poetry-core`](https://github.com/python-poetry/poetry-core) for building.

Distribution packages don't need to pull-in `poetry` during the build process.